### PR TITLE
Add TODO:Item, :Subitem, and :Subsubitem TODO style cells

### DIFF
--- a/Source/LogNotebookRuntime.wl
+++ b/Source/LogNotebookRuntime.wl
@@ -815,26 +815,91 @@ Module[{
 ]
 ]
 
-installLogNotebookStyles[nb_NotebookObject] := (
+installLogNotebookStyles[nb_NotebookObject] := With[{
+	todoDefinitions = Sequence[
+		TaggingRules -> {"TODOCompletedQ" -> False},
+		LineSpacing -> {0.95, 0},
+		CellMargins -> {{66, 0}, {2, 2}},
+		CellFrame -> {{2, 0}, {0, 0}},
+		CellFrameColor -> GrayLevel[0.7],
+		CellFrameMargins -> 5,
+		CellFrameLabelMargins -> 3,
+		CellFrameLabels -> {
+			{CreateCheckboxCell[], None},
+			{None, None}
+		}
+	]
+},
 	SetOptions[nb,
 		StyleDefinitions -> Notebook[{
 			Cell[StyleData[StyleDefinitions -> "Default.nb"] ],
 			Cell[StyleData["TODO", StyleDefinitions -> StyleData["Text"] ],
-				TaggingRules -> {"TODOCompletedQ" -> False},
-				LineSpacing -> {0.95, 0},
-				CellMargins -> {{66, 0}, {2, 2}},
-				CellFrame -> {{2, 0}, {0, 0}},
-				CellFrameColor -> GrayLevel[0.7],
-				CellFrameMargins -> 5,
-				CellFrameLabelMargins -> 3,
-				CellFrameLabels -> {
-					{CreateCheckboxCell[], None},
-					{None, None}
-				}
+				todoDefinitions,
+				"ReturnCreatesNewCell" -> True,
+				(* If the user presses the Tab key or the '*', convert this cell to a
+				   "TODO:Item" cell. *)
+				StyleKeyMapping -> {"Tab" -> "TODO:Item", "*" -> "TODO:Item"}
+			],
+			Cell[StyleData["TODO:Item", StyleDefinitions -> StyleData["Text"] ],
+				(* Override the default TODO cell frame. The gray bar looks weird as part
+				   of an item. *)
+				CellFrame -> {{0, 0}, {0, 0}},
+
+				(* The below rules are taken from the Default.nb stylesheet notebook
+				   definition for an "Item" cell. *)
+				CellDingbat -> StyleBox[
+					"\[FilledSmallSquare]",
+					Alignment -> Baseline,
+					RGBColor[0.8, 0.043, 0.008]
+				],
+				CellMargins -> {{81, 0}, {2, 2}},
+				"ReturnCreatesNewCell" -> True,
+
+				StyleKeyMapping -> {"Tab" -> "TODO:Subitem", "*" -> "TODO:Subitem", "Backspace" -> "TODO"},
+
+				todoDefinitions
+			],
+			Cell[StyleData["TODO:Subitem", StyleDefinitions -> StyleData["Text"] ],
+				(* Override the default TODO cell frame. The gray bar looks weird as part
+				   of an item. *)
+				CellFrame -> {{0, 0}, {0, 0}},
+
+				(* The below rules are taken from the Default.nb stylesheet notebook
+				   definition for an "Subitem" cell. *)
+				CellDingbat -> StyleBox[
+					"\[FilledSmallSquare]",
+					Alignment -> Baseline,
+					RGBColor[0.8, 0.043, 0.008]
+				],
+				CellMargins -> {{105, 0}, {2, 2}},
+				"ReturnCreatesNewCell" -> True,
+
+				StyleKeyMapping -> {"Tab" -> "TODO:Subsubitem", "*" -> "TODO:Subsubitem", "Backspace" -> "TODO:Item"},
+
+				todoDefinitions
+			],
+			Cell[StyleData["TODO:Subsubitem", StyleDefinitions -> StyleData["Text"] ],
+				(* Override the default TODO cell frame. The gray bar looks weird as part
+				   of an item. *)
+				CellFrame -> {{0, 0}, {0, 0}},
+
+				(* The below rules are taken from the Default.nb stylesheet notebook
+				   definition for an "Subsubitem" cell. *)
+				CellDingbat -> StyleBox[
+					"\[FilledSmallSquare]",
+					Alignment -> Baseline,
+					RGBColor[0.6, 0.6, 0.6]
+				],
+				CellMargins -> {{129, 0}, {2, 2}},
+				"ReturnCreatesNewCell" -> True,
+
+				StyleKeyMapping -> {"Backspace" -> "TODO:Subitem"},
+
+				todoDefinitions
 			]
 		}]
 	];
-)
+]
 
 
 EndPackage[]


### PR DESCRIPTION
These behave similarly to Item, Subitem, and Subsubitem cells, in that
pressing Tab or Backspace will, respectively, increase or decrease the
indentation level of the cell. This makes visually "nested" TODOs possible.