### PR TITLE
Add a small category picker bar to the bottom of the palette

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,15 @@ CreateOrganizerPalette[]
 This should open a new empty palette window. New projects may be added by clicking the
 "New Project" button and entering a name in the dialog window.
 
+### On-disk directory structure
+
+```
+{RootDirectory}/{Workspace..}/Projects/{Category..}/{Project..}/Log.nb
+```
+
+The string literal `Projects` is a historical artifact of how I have historicall organized
+my notebooks in relation to other non-notebook files.
+
 ### Credits
 
 The icons:

--- a/Source/Organizer.wl
+++ b/Source/Organizer.wl
@@ -36,7 +36,7 @@ Needs["Organizer`Palette`"]
 UpdateLogNotebooks[] := Module[{nbs, nbObj},
     nbs = FileNames[
         "Log.nb",
-        FileNameJoin[{Organizer`Palette`Private`WorkspaceDirectory[], "Projects", "Active"}],
+        Organizer`Palette`CategoryDirectory[],
         Infinity
     ];
 


### PR DESCRIPTION
This makes it possible to switch between the different Categories of
projects which are present in the current Workspace.

Also add a note to README.md about the directory structure which
Organizer uses.