### PR TITLE
Backwards incompatible: remove intermediate "Projects" directory from…

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,11 +42,8 @@ This should open a new empty palette window. New projects may be added by clicki
 ### On-disk directory structure
 
 ```
-{RootDirectory}/{Workspace..}/Projects/{Category..}/{Project..}/Log.nb
+{RootDirectory}/{Workspace..}/{Category..}/{Project..}/Log.nb
 ```
-
-The string literal `Projects` is a historical artifact of how I have historicall organized
-my notebooks in relation to other non-notebook files.
 
 ### Credits
 

--- a/Source/Palette.wl
+++ b/Source/Palette.wl
@@ -62,7 +62,7 @@ CategoryDirectory[] := Module[{name},
         PersistentValue["CG:Organizer:Category", "Local"] = name;
     ];
 
-    dir = FileNameJoin[{WorkspaceDirectory[], "Projects", name}];
+    dir = FileNameJoin[{WorkspaceDirectory[], name}];
     If[!DirectoryQ[dir],
         errorDialog[StringForm[
             "saved Category name '``' does not exist in the Workspace directory: ``",
@@ -77,7 +77,7 @@ CategoryDirectory[] := Module[{name},
 Workspaces[] := subDirectoryNames[NotebooksDirectory[]]
 
 (* Get a list of Categories which are a part of the current workspace. *)
-Categories[] := subDirectoryNames[FileNameJoin[{WorkspaceDirectory[], "Projects"}]]
+Categories[] := subDirectoryNames[WorkspaceDirectory[]]
 
 Projects[] := subDirectoryNames[CategoryDirectory[]]
 


### PR DESCRIPTION
… the on-disk directory structure expected by Organizer

Way back in the beginning of this project I thought there might be top-level categories
other than "Projects" (which now are nested within "Workspaces" anyway), but over time
none have really emerged, and this extra directory level isn't serving any real purpose.