### PR TITLE
Feature: Improve the UX of the (Notebooks|Workspace|Category)Directory[] helper functions

### DIFF
--- a/Source/Organizer.wl
+++ b/Source/Organizer.wl
@@ -13,23 +13,6 @@ If[$VersionNumber >= 12.3,
 
 (* PersistentValue["CG:Organizer:PaletteObject", "FrontEndSession"] = None; *)
 
-If[!DirectoryQ[PersistentValue["CG:Organizer:RootDirectory", "Local"]],
-	dir = SystemDialogInput[
-		"Directory",
-		FileNameDrop[PacletObject["Organizer"]["Location"], -1]
-	];
-
-    If[!DirectoryQ[dir],
-        If[dir === $Canceled,
-            Return[];
-        ];
-        Throw[StringForm["Invalid project name: ``", dir] ];
-    ];
-
-	PersistentValue["CG:Organizer:RootDirectory", "Local"] = dir;
-];
-
-
 Needs["Organizer`LogNotebookRuntime`"];
 Needs["Organizer`Palette`"]
 


### PR DESCRIPTION
  * Check for the case that no directories exist in the saved location. The old
    code would should the user a ChoiceDialog with no choices.
  * Provide better error messages, specific to the current state; not just a
    generic "bad category" error message.
  * Prompt the user to select a new root directory if the saved path does
    not exist. This makes it much less painful to rename the root directory; now
    the user doesn't have to mess with manually resetting the PersistentValue.