### PR TITLE
Bugfix: Fix shadowing warnings generated when Organizer`LogNotebookRuntime` is loaded

### DIFF
--- a/Source/LogNotebookRuntime.wl
+++ b/Source/LogNotebookRuntime.wl
@@ -17,6 +17,11 @@ FindQueueChapterCell
 FindDailyChapterCell
 GroupSelectionMove
 
+InstallLogNotebookDockedCells
+InstallLogNotebookStyles
+
+Begin["`Private`"]
+
 If[MissingQ @ PersistentValue["CG:Organizer:BackgroundColorPalette", "Local"],
 	PersistentValue["CG:Organizer:BackgroundColorPalette", "Local"] = {
 		{LightBlue, LightCyan, LightGreen},
@@ -742,7 +747,7 @@ Module[{colors, grid},
 ]
 ]
 
-installLogNotebookDockedCells[nbObj_, projName_?StringQ] := With[{
+InstallLogNotebookDockedCells[nbObj_, projName_?StringQ] := With[{
 	loadOrFail = $HeldLoadOrFail
 },
 Module[{
@@ -901,7 +906,7 @@ Module[{
 ]
 ]
 
-installLogNotebookStyles[nb_NotebookObject] := With[{
+InstallLogNotebookStyles[nb_NotebookObject] := With[{
 	todoDefinitions = Sequence[
 		TaggingRules -> {"CG:Organizer" -> {"TODOCompletedQ" -> False}},
 		LineSpacing -> {0.95, 0},
@@ -987,5 +992,7 @@ installLogNotebookStyles[nb_NotebookObject] := With[{
 	];
 ]
 
+
+End[]
 
 EndPackage[]

--- a/Source/Organizer.wl
+++ b/Source/Organizer.wl
@@ -29,8 +29,8 @@ UpdateLogNotebooks[] := Module[{nbs, nbObj},
         Function[nbPath,
             nbObj = NotebookOpen[nbPath];
 
-            installLogNotebookDockedCells[nbObj, FileNameSplit[nbPath][[-2]]];
-            installLogNotebookStyles[nbObj];
+            InstallLogNotebookDockedCells[nbObj, FileNameSplit[nbPath][[-2]]];
+            InstallLogNotebookStyles[nbObj];
         ],
         nbs
     ]

--- a/Source/Palette.wl
+++ b/Source/Palette.wl
@@ -472,8 +472,8 @@ handleStartNewProject[] := Module[{
 
     NotebookWrite[logNB, Cell["Queue", "Chapter"] ];
 
-    installLogNotebookStyles[logNB];
-    installLogNotebookDockedCells[logNB, projName];
+    InstallLogNotebookStyles[logNB];
+    InstallLogNotebookDockedCells[logNB, projName];
 
     (* TODO: Set DockedCells *)
 
@@ -554,7 +554,7 @@ handleShowQueues[] := Module[{projects, settings, nb, path, cells, timestamp, wo
     ];
 
     (* Add style definitions so that copied TODO cells render properly. *)
-    installLogNotebookStyles[nb];
+    InstallLogNotebookStyles[nb];
 
     SetOptions[nb,
         (* Disable editing. If the user wants to edit these queues, they should do it in
@@ -754,7 +754,7 @@ iHandleShowDailys[] := Enclose[Module[{
 	];
 
 	(* Add style definitions so that copied TODO cells render properly. *)
-	installLogNotebookStyles[nb];
+	InstallLogNotebookStyles[nb];
 
 	SetOptions[nb,
 		(* Disable editing. If the user wants to edit these queues, they should do it in


### PR DESCRIPTION
These occur because the body of LogNotebookRuntime.wl was not enclosed
in ``Begin["`Private`"]`` / `End[]` statements.

This is a backwards incompatible change. Any users should evaluate:

```wolfram
	Needs["Organizer`"]

	UpdateLogNotebooks[]
```

after updating to the version containing this change.