### PR TITLE
Cleanup: Standardize error handling

### DIFF
--- a/Source/Organizer.wl
+++ b/Source/Organizer.wl
@@ -22,7 +22,7 @@ Needs["Organizer`Utils`"]
 UpdateLogNotebooks[] := Try @ Module[{nbs, nbObj},
     nbs = FileNames[
         "Log.nb",
-        Organizer`Palette`WorkspaceDirectory[],
+        Confirm @ Organizer`Palette`WorkspaceDirectory[],
         Infinity
     ];
 


### PR DESCRIPTION
Clean up error propagation and handling using FailureMessage and HandleUIFailure utilities.
    
Separate raising of errors from how they are presented to the user. (This makes the
functions in this package behave more like library code, potentially useable from
outside code. Part of the effort to pacletize and publish this project.)

Instead of having calls to errorDialog/MessageDialog sprinkled throughout the code,
propagate generic Failure[..] objects using my standard wrappers (Try/FailureMessage)
for working with Enclose/Confirm based error propagation.

Add a new HandleUIFailure function for use at the top level in the UI logic. If the library
code returns something FailureQ, a MessageDialog will be shown, and Abort[] will defensively
be called.

Because HandleUIFailure should only appear at the very top in UI code, the Abort[] should
not typically have much of an effect -- the users click on the UI was the beginning of
the evaluation, which should be very nearby in the stack, and there should not be much
intervening logic. Throw[..]'ing is not desirable because that results in a message appearing
in the Window > Messages window. We're taking care to display our error already using a
MessageDialog, so we want to avoid the redundancy.