### PR TITLE
polish: Inline the Workspace... switching buttons to remove extra button click

### DIFF
--- a/Source/Palette.wl
+++ b/Source/Palette.wl
@@ -526,10 +526,10 @@ commandDropdownContents[close_Function] := Handle[_Failure] @ With[{
             ],
             With[{
                 choices = Map[
-                    # :> (
+                    workspace |-> Button[workspace, (
                         ReleaseHold[loadOrFail];
 
-                        PersistentValue["CG:Organizer:Workspace", "Local"] = #;
+                        PersistentValue["CG:Organizer:Workspace", "Local"] = workspace;
                         (* Set the category for the selected workspace. Because the
                            categories just happen to be sorted (by FileNames), "Active" is
                            typically the first category. There currently isn't a proper
@@ -538,15 +538,11 @@ commandDropdownContents[close_Function] := Handle[_Failure] @ With[{
 
 						(* OpenOrganizerPalette[] automatically refreshes the palette. *)
 						HandleUIFailure @ ConnorGray`Organizer`OpenOrganizerPalette[]
-                    )&,
+					), Background -> LightGray],
                     RaiseConfirm @ Workspaces[]
                 ]
             },
-                ActionMenu[
-                    Style["Workspace ...", 18],
-                    choices,
-                    ImageSize -> Full
-                ]
+				Splice[choices]
             ],
             Button[
                 Style["Show Queues", 20],
@@ -568,7 +564,8 @@ commandDropdownContents[close_Function] := Handle[_Failure] @ With[{
                 Method -> "Queued",
                 Background -> LightBlue
             ]
-        }
+        },
+		Spacings -> 0
     ]
 ]
 


### PR DESCRIPTION
Switching workspaces is relatively common, but the typical Organizer user is going to have a very small number of workspaces. Putting the Workspace switcher buttons in a submenu menus it is a minimum of 3 clicks to switch workspaces.

By inlining these buttons into the parent command menu, a button click is reduced.

Also fixed spacing issue in the command button menu.

![CleanShot 2023-10-06 at 00 57 29](https://github.com/ConnorGray/Organizer/assets/5759631/7a3896bd-8a69-464f-a13c-2d44477a02a4)

